### PR TITLE
#46459 Removes dependency on Playlist.sg_status

### DIFF
--- a/info.yml
+++ b/info.yml
@@ -33,7 +33,7 @@ description: "A custom Nuke node that creates a quicktime and uploads it to Shot
 
 # Required minimum versions for this item to run
 requires_shotgun_version:
-requires_core_version: "v0.18.00"
+requires_core_version: "v0.18.124"
 requires_engine_version: "v0.2.3"
 
 # the engines that this app can operate in:

--- a/python/tk_nuke_quickreview/dialog.py
+++ b/python/tk_nuke_quickreview/dialog.py
@@ -87,7 +87,7 @@ class Dialog(QtGui.QWidget):
         """
         self.ui.playlists.setToolTip(
             "<p>Shows the 10 most recently updated playlists for "
-            "the project that aren't closed and have a viewing date "
+            "the project that have a viewing date "
             "set to the future.</p>"
         )
 
@@ -100,7 +100,6 @@ class Dialog(QtGui.QWidget):
             "Playlist",
             [
                 ["project", "is", self._bundle.context.project],
-                ["sg_status", "is_not", "clsd"],
                 {
                     "filter_operator": "any",
                     "filters": [


### PR DESCRIPTION
Removes `Playlist.sg_status` filters which is present on some older sites but not on more recent ones.