### PR TITLE
SG-19344 Fix for 'Show in Panel' callback not working

### DIFF
--- a/hooks/settings.py
+++ b/hooks/settings.py
@@ -151,8 +151,9 @@ class Settings(HookBaseClass):
                 # the 'codec' knob name was changed to 'format' in Nuke 7
                 write_node["file_type"].setValue("ffmpeg")
                 write_node["format"].setValue("MOV format (mov)")
-        elif nuke.NUKE_VERSION_MAJOR >= 10 and (
-            nuke.NUKE_VERSION_MINOR > 1 or nuke.NUKE_VERSION_RELEASE > 1
+        elif nuke.NUKE_VERSION_MAJOR > 10 or (
+            nuke.NUKE_VERSION_MAJOR == 10
+            and (nuke.NUKE_VERSION_MINOR > 1 or nuke.NUKE_VERSION_RELEASE > 1)
         ):
             # In Nuke 10.0v2, the dependency on the Quicktime desktop application was removed. Because of
             # that, we have to account for changes in the .mov encoding settings in the Write node.
@@ -169,7 +170,6 @@ class Settings(HookBaseClass):
             else:
                 write_node["codec"].setValue("jpeg")
             write_node["fps"].setValue(23.97599983)
-
             # note: in older versions of nuke, this settings string represents all the quicktime
             # code settings used on windows and mac.
             write_node["settings"].setValue(

--- a/python/tk_nuke_quickreview/dialog.py
+++ b/python/tk_nuke_quickreview/dialog.py
@@ -460,8 +460,8 @@ class Dialog(QtGui.QWidget):
         for app in self._bundle.engine.apps.values():
             if app.name == "tk-multi-shotgunpanel":
                 # panel is loaded
-                launch_panel_fn = lambda panel_app=app: self._navigate_panel_and_close(
-                    panel_app, self._version_id
+                launch_panel_fn = lambda: self._navigate_panel_and_close(
+                    app, self._version_id
                 )
                 self.ui.jump_to_panel.clicked.connect(launch_panel_fn)
                 found_panel = True

--- a/python/tk_nuke_quickreview/dialog.py
+++ b/python/tk_nuke_quickreview/dialog.py
@@ -465,6 +465,7 @@ class Dialog(QtGui.QWidget):
                 )
                 self.ui.jump_to_panel.clicked.connect(launch_panel_fn)
                 found_panel = True
+                break
 
         if not found_panel:
             # no panel, so hide button


### PR DESCRIPTION
The argument `panel_app` was being passed a boolean by the `clicked` method which was breaking the callback. This `checked` parameter is optional and I assume it wasn't being passed in PySide which is why this worked at some point. 

We were also treating the Nuke versions incorrectly when deciding on which path to take for setting values on the write node. We were treating versions like 12.0v1 and 12.1v1 as being older than 10.0v2 because of a logic issue with the `if` statement