### PR TITLE
SG-20925 Formalize the deprecation of python 2.6 support in toolkit

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -32,7 +32,7 @@ repos:
     - id: trailing-whitespace
   # Leave black at the bottom so all touchups are done before it is run.
   - repo: https://github.com/ambv/black
-    rev: 19.10b0
+    rev: 22.3.0
     hooks:
     - id: black
       language_version: python3

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-[![Python 2.6 2.7 3.7](https://img.shields.io/badge/python-2.6%20%7C%202.7%20%7C%203.7-blue.svg)](https://www.python.org/)
+[![Python 2.7 3.7](https://img.shields.io/badge/python-2.7%20%7C%203.7-blue.svg)](https://www.python.org/)
 [![Build Status](https://dev.azure.com/shotgun-ecosystem/Toolkit/_apis/build/status/Apps/tk-nuke-quickreview?repoName=shotgunsoftware%2Ftk-nuke-quickreview&branchName=master)](https://dev.azure.com/shotgun-ecosystem/Toolkit/_build/latest?definitionId=94&repoName=shotgunsoftware%2Ftk-nuke-quickreview&branchName=master)
 [![Code style: black](https://img.shields.io/badge/code%20style-black-000000.svg)](https://github.com/psf/black)
 [![Linting](https://img.shields.io/badge/PEP8%20by-Hound%20CI-a873d1.svg)](https://houndci.com)


### PR DESCRIPTION
This PR includes the actions to remove Python 2.6 support in toolkit:
        - Remove python 2.6 badges
        - Update setup.py to drop support for 2.6
        - Update the documentation and the developer.shotgunsoftware.com doc site