### PR TITLE
SG-36246 Drop compatibility with Python 2

### DIFF
--- a/hooks/settings.py
+++ b/hooks/settings.py
@@ -9,7 +9,6 @@
 # not expressly granted therein are reserved by Shotgun Software Inc.
 
 import sgtk
-import sys
 import os
 import nuke
 import datetime

--- a/hooks/settings.py
+++ b/hooks/settings.py
@@ -107,7 +107,7 @@ class Settings(HookBaseClass):
 
         # now try to see if we are in a normal work file
         # in that case deduce the name from it
-        current_scene_path = str(nuke.root().name())
+        current_scene_path = nuke.root().name()
 
         if current_scene_path and current_scene_path != "Root":
             current_scene_path = current_scene_path.replace("/", os.path.sep)

--- a/hooks/settings.py
+++ b/hooks/settings.py
@@ -14,7 +14,6 @@ import os
 import nuke
 import datetime
 
-from tank_vendor import six
 
 HookBaseClass = sgtk.get_hook_baseclass()
 
@@ -108,8 +107,7 @@ class Settings(HookBaseClass):
 
         # now try to see if we are in a normal work file
         # in that case deduce the name from it
-        current_scene_path = nuke.root().name()
-        current_scene_path = six.ensure_str(current_scene_path)
+        current_scene_path = str(nuke.root().name())
 
         if current_scene_path and current_scene_path != "Root":
             current_scene_path = current_scene_path.replace("/", os.path.sep)

--- a/python/tk_nuke_quickreview/dialog.py
+++ b/python/tk_nuke_quickreview/dialog.py
@@ -13,7 +13,6 @@ import sgtk
 import tempfile
 import datetime
 from sgtk.platform.qt import QtCore, QtGui
-from tank_vendor import six
 
 from .ui.dialog import Ui_Dialog
 
@@ -354,10 +353,10 @@ class Dialog(QtGui.QWidget):
         """
         # get inputs - these come back as unicode so make sure convert to utf-8
         version_name = self.ui.version_name.text()
-        version_name = six.ensure_str(version_name)
+        version_name = str(version_name)
 
         description = self.ui.description.toPlainText()
-        description = six.ensure_str(description)
+        description = str(description)
 
         # set metadata
         self._setup_formatting(version_name)

--- a/python/tk_nuke_quickreview/dialog.py
+++ b/python/tk_nuke_quickreview/dialog.py
@@ -351,12 +351,10 @@ class Dialog(QtGui.QWidget):
         """
         Carry out the render and upload.
         """
-        # get inputs - these come back as unicode so make sure convert to utf-8
+        # get inputs
         version_name = self.ui.version_name.text()
-        version_name = str(version_name)
 
         description = self.ui.description.toPlainText()
-        description = str(description)
 
         # set metadata
         self._setup_formatting(version_name)


### PR DESCRIPTION
Function `toPlainText` will return an `str` type: https://doc.qt.io/qtforpython-5/PySide2/QtWidgets/QTextEdit.html#PySide2.QtWidgets.PySide2.QtWidgets.QTextEdit.toPlainText

Function `name` for a nuke `Node` object will return an `str` type: https://learn.foundry.com/nuke/developers/130/pythondevguide/_autosummary/nuke.Node.html#nuke.Node.name

