### PR TITLE
SG-43662 Drop Python 3.7 support

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -32,7 +32,7 @@ repos:
     - id: trailing-whitespace
   # Leave black at the bottom so all touchups are done before it is run.
   - repo: https://github.com/ambv/black
-    rev: 26.1.0
+    rev: 26.5.1
     hooks:
     - id: black
       language_version: python3

--- a/info.yml
+++ b/info.yml
@@ -35,6 +35,7 @@ description: "A custom Nuke node that creates a quicktime and uploads it to Flow
 requires_shotgun_version:
 requires_core_version: "v0.19.8"
 requires_engine_version: "v0.2.3"
+minimum_python_version: "3.9"
 
 # the engines that this app can operate in:
 supported_engines: [tk-nuke]


### PR DESCRIPTION
## Summary

- Set `minimum_python_version: 3.9` in `info.yml` to declare that this app no longer supports Python 3.7
- Bumped pre-commit hook versions

## Test plan

- [ ] Verify `info.yml` contains `minimum_python_version: 3.9`
- [ ] Pre-commit passes cleanly